### PR TITLE
Feature (Issue #41): Add new Admin Project Details (<AdminEditProjectForm />) page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,15 +1,19 @@
 // Import React Components
 import React, { useState, useEffect, useContext } from "react";
 import { Route, Switch } from "react-router-dom";
-import AboutPage from "./routes/aboutPage";
-import ProjectsPage from "./routes/projectsPage";
-import AdminPanel from "./Components/AdminPanel/AdminPanel";
+
+// Temporary Data
 import STORE from "./STORE";
 
 // State Management
 import { GlobalContext } from "./Context/GlobalContext";
 import NotFound from "./routes/notFoundPage";
 
+// Import Custom Components
+import AboutPage from "./routes/aboutPage";
+import ProjectsPage from "./routes/projectsPage";
+import AdminPanel from "./Components/AdminPanel/AdminPanel";
+import AdminProjectDetails from "./Components/AdminProjectDetails/AdminProjectDetails";
 export default function App() {
   const [hasError, setHasError] = useState("");
   const { projects, setProjects } = useContext(GlobalContext);
@@ -26,6 +30,19 @@ export default function App() {
           <Route exact path="/" component={AboutPage} />
           <Route exact path="/projects" component={ProjectsPage} />
           <Route exact path="/admin" component={AdminPanel} />
+          <Route
+            exact
+            path="/admin/projects/:project_id"
+            component={(routeProps) => (
+              <AdminProjectDetails
+                project={projects.find(
+                  (project) =>
+                    project.project_id ===
+                    Number(routeProps.match.params.project_id)
+                )}
+              />
+            )}
+          />
           <Route component={NotFound} />
         </Switch>
       </main>

--- a/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
+++ b/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
@@ -202,8 +202,6 @@ const AdminEditProjectForm = (props) => {
                     </div>
                   </div>
                   <div className="adminEditProjectForm__form_row adminEditProjectForm__lang_add_row">
-                    {/* <label htmlFor="">
-                    </label> */}
                     <input
                       className="adminEditProjectForm__lang_input"
                       type="text"

--- a/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
+++ b/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
@@ -5,10 +5,10 @@ const AdminEditProjectForm = (props) => {
   const { project } = props; //Passed on project based on user click and project_id
   console.log(project);
 
-  const [projectName, setProjectName] = useState({
-    value: project.project_name,
-    touched: "",
-  });
+  // const [projectName, setProjectName] = useState({
+  //   value: project.project_name,
+  //   touched: "",
+  // });
   const [clientName, setClientName] = useState({
     value: project.client_name || "", //pulls in from temp data
     touched: "",
@@ -43,14 +43,15 @@ const AdminEditProjectForm = (props) => {
   // // Get Members Voted Data
   const getMembersVoted = membersVoted.value.map((member) => (
     // console.log(member);
-    <tr key={member.project_id}>
+    <tr key={project.table_vote.table_vote_id} project={project}>
       <td className="members_voted__member_data">{member.voter_name}</td>
       <td className="members_voted__member_data">{member.voter_slack_name}</td>
+      <td className="members_voted__member_data">{member.voter_email}</td>
     </tr>
   ));
 
   const getMembersSignedUp = membersSignedUp.value.map((member) => (
-    <tr key={member.project_id}>
+    <tr key={project.project_id} project={project}>
       <td className="members_voted__member_data">{member.signup_name}</td>
       <td className="members_voted__member_data">
         {member.signup_github_name}
@@ -60,47 +61,53 @@ const AdminEditProjectForm = (props) => {
   ));
   return (
     <>
-      <div
-        className="adminEditProjectForm__container"
-        key={project.project_id}
-        project={project}
-      >
+      <div className="adminEditProjectForm__container">
         <FormHeader project={project} />
-        <form action="" className="" key={project.project_id}>
-          <div className="adminEditProjectForm__form_row">
-            <div className="adminEditProjectForm__form_col">
-              <label htmlFor="">Contact Name</label>
-              <input
-                className="adminEditProjectForm__contact_info"
-                type="text"
-                name="client_name"
-                defaultValue={clientName.value}
-                // onChange={}
-              />
-              <label htmlFor="">Contact Email</label>
-              <input
-                className="adminEditProjectForm__contact_info"
-                type="text"
-                name="client_email"
-                defaultValue={clientEmail.value}
-                // onChange={}
-              />
-            </div>
-            <div className="adminEditProjectForm__form_row">
+        <div className="adminEditProjectForm__form_container_col">
+          <form
+            action=""
+            className="adminEditProjectForm__form"
+            key={project.project_id}
+          >
+            <div className="adminEditProjectForm__form_row adminEditProjectForm__contact_info">
               <div className="adminEditProjectForm__form_col">
-                <label htmlFor="">Company Name</label>
+                <label htmlFor="contact_name">Contact Name</label>
                 <input
-                  className="adminEditProjectForm__contact_info"
+                  className="adminEditProjectForm__contact_input"
+                  type="text"
+                  name="client_name"
+                  defaultValue={clientName.value}
+                  // onChange={}
+                />
+              </div>
+              <div className="adminEditProjectForm__form_col">
+                <label htmlFor="contact_email">Contact Email</label>
+                <input
+                  className="adminEditProjectForm__contact_input"
+                  type="text"
+                  name="client_email"
+                  defaultValue={clientEmail.value}
+                  // onChange={}
+                />
+              </div>
+            </div>
+            <div className="adminEditProjectForm__form_row adminEditProjectForm__company_info">
+              <div className="adminEditProjectForm__form_col">
+                <label htmlFor="company_name">Company Name</label>
+                <input
+                  className="adminEditProjectForm__contact_input"
                   type="text"
                   name="client_company"
                   defaultValue={clientCompany.value}
                   // onChange={}
                 />
-                <label htmlFor="">
+              </div>
+              <div className="adminEditProjectForm__form_col">
+                <label htmlFor="project_start_date">
                   Project Start Date <span>xxx-xxx-xxxx</span>
                 </label>
                 <input
-                  className="adminEditProjectForm__contact_info"
+                  className="adminEditProjectForm__contact_input"
                   type="text"
                   name="client_email"
                   defaultValue={startDate.value}
@@ -108,166 +115,223 @@ const AdminEditProjectForm = (props) => {
                 />
               </div>
             </div>
-          </div>
-          <div className="adminEditProjectForm__form_row">
-            <div className="adminEditProjectForm__form_col">
-              <label htmlFor="">Project Description</label>
-              <textarea
-                className="adminEditProjectForm__textarea"
-                name="project_desc"
-                rows="8"
-                cols="63"
-                defaultValue={projectDesc.value}
-              ></textarea>
-            </div>
-          </div>
-          {/* Tech Stack */}
-          <div className="adminEditProjectForm__form_row">
-            <div className="adminEditProjectForm__form_col">
-              <div>
-                <input
-                  type="checkbox"
-                  name="langs"
-                  id="langs_python"
-                  defaultValue="Python"
-                />
-                <label htmlFor="langs_langs_python">Python</label>
-              </div>
-              <div>
-                <input
-                  type="checkbox"
-                  name="langs"
-                  id="langs_javascript"
-                  defaultValue="JavaScript"
-                />
-                <label htmlFor="langs_javascript">JavaScript</label>
-              </div>
-              <div>
-                <input
-                  type="checkbox"
-                  name="langs"
-                  id="langs_java"
-                  defaultValue="Java"
-                />
-                <label htmlFor="langs_java">Java</label>
-              </div>
-            </div>
-            <div className="adminEditProjectForm__form_col">
-              <div>
-                <input type="checkbox" name="langs" id="langs_c#" value="C#" />{" "}
-                <label htmlFor="langs_php">C#</label>
-              </div>
-              <div>
-                <input
-                  type="checkbox"
-                  name="langs"
-                  id="langs_php"
-                  defaultValue="PHP"
-                />
-                <label htmlFor="langs_php">PHP</label>
-              </div>
-              <div>
-                <input type="checkbox" name="langs" id="langs_" value="C++" />
-                <label htmlFor="langs_php">C++</label>
-              </div>
-            </div>
-          </div>
-          {/* Project Status */}
-          <div className="adminEditProjectForm__form_row">
-            <div className="adminEditProjectForm__form_col">
-              <div>
-                <input type="checkbox" name="langs" id="langs_c#" value="C#" />
-                <label htmlFor="langs_php">Sign Up</label>
-              </div>
-              <div>
-                <input
-                  type="checkbox"
-                  name="langs"
-                  id="langs_php"
-                  value="PHP"
-                />{" "}
-                <label htmlFor="langs_php">Active</label>
-              </div>
-            </div>
-            <div className="adminEditProjectForm__form_col">
-              <div>
-                <input type="checkbox" name="langs" id="langs_c#" value="C#" />
-                <label htmlFor="langs_php">Open Vote</label>
-              </div>
-              <div>
-                <input
-                  type="checkbox"
-                  name="langs"
-                  id="langs_php"
-                  defaultValue="PHP"
-                />
-                <label htmlFor="langs_php">Completed</label>
-              </div>
-            </div>
-          </div>
-          <div
-            className="member_data__container"
-            key={project.table_vote.table_vote_id}
-          >
             <div className="adminEditProjectForm__form_row">
-              <h3 className="adminEditProjectForm__section_header">
-                Member Data
-              </h3>
+              <div className="adminEditProjectForm__form_col">
+                <label htmlFor="project_desc">Project Description</label>
+                <textarea
+                  className="adminEditProjectForm__textarea"
+                  name="project_desc"
+                  rows="8"
+                  cols="49"
+                  defaultValue={projectDesc.value}
+                ></textarea>
+              </div>
             </div>
-            <div className="adminEditProjectForm__form_row">
-              <span className="adminEditProjectForm__section_sub_header">
-                Team Members Voted
-              </span>
+
+            {/* Tech Stack */}
+            <div className="adminEditProjectForm__form_row adminEditProjectForm__checkbox_squares">
+              <div className="adminEditProjectForm__form_col adminEditProjectForm__project_tech_container">
+                <span className="adminEditProjectForm__tech_stack_header">
+                  Tech Stack
+                </span>
+                <div className="adminEditProjectForm__form_container_square">
+                  <div className="adminEditProjectForm__form_row adminEditProjectForm__square_row">
+                    <div className="adminEditProjectForm__form_col adminEditProjectForm__square_col">
+                      <div>
+                        <input
+                          type="checkbox"
+                          name="langs"
+                          id="langs_python"
+                          defaultValue="Python"
+                          className="adminEditProjectForm__input_checkbox"
+                        />
+                        <label htmlFor="langs_python">Python</label>
+                      </div>
+                      <div>
+                        <input
+                          type="checkbox"
+                          name="langs"
+                          id="langs_javascript"
+                          defaultValue="JavaScript"
+                          className="adminEditProjectForm__input_checkbox"
+                        />
+                        <label htmlFor="langs_javascript">JavaScript</label>
+                      </div>
+                      <div>
+                        <input
+                          type="checkbox"
+                          name="langs"
+                          id="langs_java"
+                          defaultValue="Java"
+                          className="adminEditProjectForm__input_checkbox"
+                        />
+                        <label htmlFor="langs_java">Java</label>
+                      </div>
+                    </div>
+                    <div className="adminEditProjectForm__form_col">
+                      <div>
+                        <input
+                          type="checkbox"
+                          name="langs"
+                          id="langs_c#"
+                          defaultValue="C#"
+                          className="adminEditProjectForm__input_checkbox"
+                        />
+                        <label htmlFor="langs_c#">C#</label>
+                      </div>
+                      <div>
+                        <input
+                          type="checkbox"
+                          name="langs"
+                          id="langs_php"
+                          defaultValue="PHP"
+                          className="adminEditProjectForm__input_checkbox"
+                        />
+                        <label htmlFor="langs_php">PHP</label>
+                      </div>
+                      <div>
+                        <input
+                          type="checkbox"
+                          name="langs"
+                          id="langs_c++"
+                          defaultValue="C++"
+                          className="adminEditProjectForm__input_checkbox"
+                        />
+                        <label htmlFor="langs_c++">C++</label>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="adminEditProjectForm__form_row adminEditProjectForm__lang_add_row">
+                    {/* <label htmlFor="">
+                    </label> */}
+                    <input
+                      className="adminEditProjectForm__lang_input"
+                      type="text"
+                      name="new_language"
+                      placeholder="Language"
+                      // onChange={}
+                    />
+                    <button className="adminEditProjectForm__lang_add_btn">
+                      Add
+                    </button>
+                  </div>
+                </div>
+              </div>
+              {/* Project Status */}
+              <div className="adminEditProjectForm__form_col adminEditProjectForm__project_status_container">
+                <div className="adminEditProjectForm__form_col">
+                  <span className="adminEditProjectForm__tech_stack_header">
+                    Status
+                  </span>
+                  <div className="adminEditProjectForm__form_container_square">
+                    <div className="adminEditProjectForm__form_row adminEditProjectForm__square_row">
+                      <div className="adminEditProjectForm__form_col adminEditProjectForm__square_col">
+                        <div>
+                          <input
+                            type="checkbox"
+                            name="status"
+                            id="status_sign_up"
+                            defaultValue="Sign Up"
+                            className="adminEditProjectForm__input_checkbox"
+                          />
+                          <label htmlFor="status_sign_up">Sign Up</label>
+                        </div>
+                        <div>
+                          <input
+                            type="checkbox"
+                            name="status"
+                            id="status_active"
+                            defaultValue="Active"
+                            className="adminEditProjectForm__input_checkbox"
+                          />
+                          <label htmlFor="status_active">Active</label>
+                        </div>
+                      </div>
+                      <div className="adminEditProjectForm__form_col">
+                        <div>
+                          <input
+                            type="checkbox"
+                            name="status"
+                            id="status_open_vote"
+                            defaultValue="Open Vote"
+                            className="adminEditProjectForm__input_checkbox"
+                          />
+                          <label htmlFor="status_open_vote">Open Vote</label>
+                        </div>
+                        <div>
+                          <input
+                            type="checkbox"
+                            name="status"
+                            id="status_completed"
+                            defaultValue="Completed"
+                            className="adminEditProjectForm__input_checkbox"
+                          />
+                          <label htmlFor="status_completed">Completed</label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
-            <table key={project.table_vote.table_vote_id}>
-              <thead className="adminEditProjectForm__table_header">
-                <tr>
-                  <th>
-                    <h5>Name</h5>
-                  </th>
-                </tr>
-                <tr>
-                  <th>
-                    <h5>Slack Handle || Email</h5>
-                  </th>
-                </tr>
-              </thead>
-              <tbody key={project.table_vote.table_vote_id}>
-                {getMembersVoted}
-                <tr className="adminEditProjectForm__horizontal_line"></tr>
-                {getMembersSignedUp}
-              </tbody>
-            </table>
-            <div className="adminEditProjectForm__form_row">
-              <span className="adminEditProjectForm__section_sub_header">
-                Team Members Signed Up
-              </span>
+            {/* Member Data */}
+            <div className="memberData__container">
+              <div className="adminEditProjectForm__form_row">
+                <h5 className="adminEditProjectForm__section_header">
+                  Member Data
+                </h5>
+              </div>
+              <div className="adminEditProjectForm__form_row">
+                <span className="adminEditProjectForm__section_sub_header">
+                  Team Members Voted
+                </span>
+              </div>
+              <table>
+                <thead className="adminEditProjectForm__table_header">
+                  <tr>
+                    <th>
+                      <h5>Name</h5>
+                    </th>
+                    <th>
+                      <h5>Slack Handle</h5>
+                    </th>
+                    <th>
+                      <h5>Email</h5>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody key={project.project_id}>
+                  {getMembersVoted}
+                  <tr className="adminEditProjectForm__horizontal_line"></tr>
+                </tbody>
+              </table>
+              <div className="adminEditProjectForm__form_row">
+                <span className="adminEditProjectForm__section_sub_header">
+                  Team Members Signed Up
+                </span>
+              </div>
+              <table>
+                <thead className="adminEditProjectForm__table_header">
+                  <tr>
+                    <th>
+                      <h5>Name</h5>
+                    </th>
+                    <th>
+                      <h5>GitHub Handle</h5>
+                    </th>
+                    <th>
+                      <h5>Email</h5>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="adminEditProjectForm__horizontal_line"></tr>
+                  {getMembersSignedUp}
+                </tbody>
+              </table>
             </div>
-            <table>
-              <thead className="adminEditProjectForm__table_header">
-                <tr>
-                  <th>
-                    <h5>Name</h5>
-                  </th>
-                </tr>
-                <tr>
-                  <th>
-                    <h5>GitHub Handle</h5>
-                  </th>
-                </tr>
-                <tr>
-                  <th>
-                    <h5>Email</h5>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr className="adminEditProjectForm__horizontal_line"></tr>
-                {getMembersSignedUp}
-              </tbody>
-            </table>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
     </>
   );

--- a/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
+++ b/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
@@ -55,6 +55,8 @@ const AdminEditProjectForm = (props) => {
                 value={clientEmail.value}
                 // onChange={}
               />
+            </div>
+            <div className="adminEditProjectForm_form_row">
               <div className="adminEditProjectForm_form_col">
                 <label>Company Name</label>
                 <input
@@ -74,21 +76,104 @@ const AdminEditProjectForm = (props) => {
                 />
               </div>
             </div>
-            <div className="adminEditProjectForm_form_row">
-              <div className="adminEditProjectForm_form_col">
-                <label>Project Description</label>
-                <textarea
-                  name="project_desc"
-                  rows="8"
-                  cols="63"
-                  value={projectDesc.value}
-                >
-                  It was a dark and stormy night...
-                </textarea>
+          </div>
+          <div className="adminEditProjectForm_form_row">
+            <div className="adminEditProjectForm_form_col">
+              <label>Project Description</label>
+              <textarea
+                name="project_desc"
+                rows="8"
+                cols="63"
+                value={projectDesc.value}
+              >
+                It was a dark and stormy night...
+              </textarea>
+            </div>
+          </div>
+          {/* Tech Stack */}
+          <div className="adminEditProjectForm_form_row">
+            <div className="adminEditProjectForm_form_col">
+              <div>
+                <input
+                  type="checkbox"
+                  name="langs"
+                  id="langs_python"
+                  value="Python"
+                />
+                <label for="langs_langs_python">Python</label>
+              </div>
+              <div>
+                <input
+                  type="checkbox"
+                  name="langs"
+                  id="langs_javascript"
+                  value="JavaScript"
+                />
+                <label for="langs_javascript">JavaScript</label>
+              </div>
+              <div>
+                <input
+                  type="checkbox"
+                  name="langs"
+                  id="langs_java"
+                  value="Java"
+                />
+                <label for="langs_java">Java</label>
+              </div>
+            </div>
+            <div className="adminEditProjectForm_form_col">
+              <div>
+                <input type="checkbox" name="langs" id="langs_c#" value="C#" />{" "}
+                <label for="langs_php">C#</label>
+              </div>
+              <div>
+                <input
+                  type="checkbox"
+                  name="langs"
+                  id="langs_php"
+                  value="PHP"
+                />{" "}
+                <label for="langs_php">PHP</label>
+              </div>{" "}
+              <div>
+                <input type="checkbox" name="langs" id="langs_" value="C++" />
+                <label for="langs_php">C++</label>
               </div>
             </div>
           </div>
-          {/* </div> */}
+          {/* Project Status */}
+          <div className="adminEditProjectForm_form_row">
+            <div className="adminEditProjectForm_form_col">
+              <div>
+                <input type="checkbox" name="langs" id="langs_c#" value="C#" />
+                <label for="langs_php">Sign Up</label>
+              </div>
+              <div>
+                <input
+                  type="checkbox"
+                  name="langs"
+                  id="langs_php"
+                  value="PHP"
+                />{" "}
+                <label for="langs_php">Active</label>
+              </div>
+            </div>
+            <div className="adminEditProjectForm_form_col">
+              <div>
+                <input type="checkbox" name="langs" id="langs_c#" value="C#" />
+                <label for="langs_php">Open Vote</label>
+              </div>
+              <div>
+                <input
+                  type="checkbox"
+                  name="langs"
+                  id="langs_php"
+                  value="PHP"
+                />{" "}
+                <label for="langs_php">Completed</label>
+              </div>
+            </div>
+          </div>
         </form>
       </div>
     </>

--- a/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
+++ b/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
@@ -1,0 +1,98 @@
+import React, { useEffect, useState, useContext } from "react";
+import { GlobalContext } from "../../Context/GlobalContext";
+const AdminEditProjectForm = (props) => {
+  const { project } = props; //Passed on project based on user click and project_id
+  console.log(project);
+
+  const [clientName, setClientName] = useState({
+    value: project.client_name || "", //pulls in from temp data
+    touched: "",
+  });
+  const [clientEmail, setClientEmail] = useState({
+    value: project.client_email || "",
+    touched: "",
+  });
+  const [clientCompany, setClientCompany] = useState({
+    value: project.client_company,
+    touched: "",
+  });
+  const [startDate, setStartDate] = useState({ value: project.date });
+  const [projectDesc, setProjectDesc] = useState({
+    value: project.project_desc,
+    touched: "",
+  });
+  const [techStack, setTechStack] = useState({
+    value: project.tech_stack,
+    touched: "",
+  });
+  const [membersVoted, setMembersVoted] = useState({
+    value: project.members_voted,
+    touched: "",
+  });
+  const [membersSignedUp, setMembersSignedUp] = useState({
+    value: project.members_signed_up,
+    touched: "",
+  });
+
+  return (
+    <>
+      <h2>{clientName.value}</h2>
+      <div className="adminEditProjectForm_container">
+        <form action="" className="">
+          <div className="adminEditProjectForm_form_row">
+            <div className="adminEditProjectForm_form_col">
+              <label>Contact Name</label>
+              <input
+                type="text"
+                name="client_name"
+                value={clientName.value}
+                // onChange={}
+              />
+              <label>Contact Email</label>
+              <input
+                type="text"
+                name="client_email"
+                value={clientEmail.value}
+                // onChange={}
+              />
+              <div className="adminEditProjectForm_form_col">
+                <label>Company Name</label>
+                <input
+                  type="text"
+                  name="client_company"
+                  value={clientCompany.value}
+                  // onChange={}
+                />
+                <label>
+                  Project Start Date <span>xxx-xxx-xxxx</span>
+                </label>
+                <input
+                  type="text"
+                  name="client_email"
+                  value={startDate.value}
+                  // onChange={}
+                />
+              </div>
+            </div>
+            <div className="adminEditProjectForm_form_row">
+              <div className="adminEditProjectForm_form_col">
+                <label>Project Description</label>
+                <textarea
+                  name="project_desc"
+                  rows="8"
+                  cols="63"
+                  value={projectDesc.value}
+                >
+                  It was a dark and stormy night...
+                </textarea>
+              </div>
+            </div>
+          </div>
+          {/* </div> */}
+        </form>
+      </div>
+    </>
+  );
+};
+
+export default AdminEditProjectForm;

--- a/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
+++ b/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
@@ -60,9 +60,13 @@ const AdminEditProjectForm = (props) => {
   ));
   return (
     <>
-      <div className="adminEditProjectForm__container">
+      <div
+        className="adminEditProjectForm__container"
+        key={project.project_id}
+        project={project}
+      >
         <FormHeader project={project} />
-        <form action="" className="">
+        <form action="" className="" key={project.project_id}>
           <div className="adminEditProjectForm__form_row">
             <div className="adminEditProjectForm__form_col">
               <label htmlFor="">Contact Name</label>
@@ -201,7 +205,10 @@ const AdminEditProjectForm = (props) => {
               </div>
             </div>
           </div>
-          <div className="member_data__container">
+          <div
+            className="member_data__container"
+            key={project.table_vote.table_vote_id}
+          >
             <div className="adminEditProjectForm__form_row">
               <h3 className="adminEditProjectForm__section_header">
                 Member Data
@@ -212,17 +219,20 @@ const AdminEditProjectForm = (props) => {
                 Team Members Voted
               </span>
             </div>
-            <table>
+            <table key={project.table_vote.table_vote_id}>
               <thead className="adminEditProjectForm__table_header">
-                <th>
-                  <h5>Name</h5>
-                </th>
-                <th>
-                  <h5>Slack Handle || Email</h5>
-                </th>
+                <tr>
+                  <th>
+                    <h5>Name</h5>
+                  </th>
+                </tr>
+                <tr>
+                  <th>
+                    <h5>Slack Handle || Email</h5>
+                  </th>
+                </tr>
               </thead>
-              <tbody>
-                {/* <tr>{getMembersVoted}</tr> */}
+              <tbody key={project.table_vote.table_vote_id}>
                 {getMembersVoted}
                 <tr className="adminEditProjectForm__horizontal_line"></tr>
                 {getMembersSignedUp}
@@ -235,15 +245,21 @@ const AdminEditProjectForm = (props) => {
             </div>
             <table>
               <thead className="adminEditProjectForm__table_header">
-                <th>
-                  <h5>Name</h5>
-                </th>
-                <th>
-                  <h5>GitHub Handle</h5>
-                </th>
-                <th>
-                  <h5>Email</h5>
-                </th>
+                <tr>
+                  <th>
+                    <h5>Name</h5>
+                  </th>
+                </tr>
+                <tr>
+                  <th>
+                    <h5>GitHub Handle</h5>
+                  </th>
+                </tr>
+                <tr>
+                  <th>
+                    <h5>Email</h5>
+                  </th>
+                </tr>
               </thead>
               <tbody>
                 <tr className="adminEditProjectForm__horizontal_line"></tr>

--- a/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
+++ b/client/src/Components/AdminEditProjectForm/AdminEditProjectForm.js
@@ -1,9 +1,14 @@
 import React, { useEffect, useState, useContext } from "react";
 import { GlobalContext } from "../../Context/GlobalContext";
+import FormHeader from "./FormHeader";
 const AdminEditProjectForm = (props) => {
   const { project } = props; //Passed on project based on user click and project_id
   console.log(project);
 
+  const [projectName, setProjectName] = useState({
+    value: project.project_name,
+    touched: "",
+  });
   const [clientName, setClientName] = useState({
     value: project.client_name || "", //pulls in from temp data
     touched: "",
@@ -26,127 +31,149 @@ const AdminEditProjectForm = (props) => {
     touched: "",
   });
   const [membersVoted, setMembersVoted] = useState({
-    value: project.members_voted,
+    value: project.table_vote,
     touched: "",
   });
   const [membersSignedUp, setMembersSignedUp] = useState({
-    value: project.members_signed_up,
+    value: project.table_signup,
     touched: "",
   });
+  console.log(membersVoted.value[0].voter_name);
 
+  // // Get Members Voted Data
+  const getMembersVoted = membersVoted.value.map((member) => (
+    // console.log(member);
+    <tr key={member.project_id}>
+      <td className="members_voted__member_data">{member.voter_name}</td>
+      <td className="members_voted__member_data">{member.voter_slack_name}</td>
+    </tr>
+  ));
+
+  const getMembersSignedUp = membersSignedUp.value.map((member) => (
+    <tr key={member.project_id}>
+      <td className="members_voted__member_data">{member.signup_name}</td>
+      <td className="members_voted__member_data">
+        {member.signup_github_name}
+      </td>
+      <td className="members_voted__member_data">{member.signup_email}</td>
+    </tr>
+  ));
   return (
     <>
-      <h2>{clientName.value}</h2>
-      <div className="adminEditProjectForm_container">
+      <div className="adminEditProjectForm__container">
+        <FormHeader project={project} />
         <form action="" className="">
-          <div className="adminEditProjectForm_form_row">
-            <div className="adminEditProjectForm_form_col">
-              <label>Contact Name</label>
+          <div className="adminEditProjectForm__form_row">
+            <div className="adminEditProjectForm__form_col">
+              <label htmlFor="">Contact Name</label>
               <input
+                className="adminEditProjectForm__contact_info"
                 type="text"
                 name="client_name"
-                value={clientName.value}
+                defaultValue={clientName.value}
                 // onChange={}
               />
-              <label>Contact Email</label>
+              <label htmlFor="">Contact Email</label>
               <input
+                className="adminEditProjectForm__contact_info"
                 type="text"
                 name="client_email"
-                value={clientEmail.value}
+                defaultValue={clientEmail.value}
                 // onChange={}
               />
             </div>
-            <div className="adminEditProjectForm_form_row">
-              <div className="adminEditProjectForm_form_col">
-                <label>Company Name</label>
+            <div className="adminEditProjectForm__form_row">
+              <div className="adminEditProjectForm__form_col">
+                <label htmlFor="">Company Name</label>
                 <input
+                  className="adminEditProjectForm__contact_info"
                   type="text"
                   name="client_company"
-                  value={clientCompany.value}
+                  defaultValue={clientCompany.value}
                   // onChange={}
                 />
-                <label>
+                <label htmlFor="">
                   Project Start Date <span>xxx-xxx-xxxx</span>
                 </label>
                 <input
+                  className="adminEditProjectForm__contact_info"
                   type="text"
                   name="client_email"
-                  value={startDate.value}
+                  defaultValue={startDate.value}
                   // onChange={}
                 />
               </div>
             </div>
           </div>
-          <div className="adminEditProjectForm_form_row">
-            <div className="adminEditProjectForm_form_col">
-              <label>Project Description</label>
+          <div className="adminEditProjectForm__form_row">
+            <div className="adminEditProjectForm__form_col">
+              <label htmlFor="">Project Description</label>
               <textarea
+                className="adminEditProjectForm__textarea"
                 name="project_desc"
                 rows="8"
                 cols="63"
-                value={projectDesc.value}
-              >
-                It was a dark and stormy night...
-              </textarea>
+                defaultValue={projectDesc.value}
+              ></textarea>
             </div>
           </div>
           {/* Tech Stack */}
-          <div className="adminEditProjectForm_form_row">
-            <div className="adminEditProjectForm_form_col">
+          <div className="adminEditProjectForm__form_row">
+            <div className="adminEditProjectForm__form_col">
               <div>
                 <input
                   type="checkbox"
                   name="langs"
                   id="langs_python"
-                  value="Python"
+                  defaultValue="Python"
                 />
-                <label for="langs_langs_python">Python</label>
+                <label htmlFor="langs_langs_python">Python</label>
               </div>
               <div>
                 <input
                   type="checkbox"
                   name="langs"
                   id="langs_javascript"
-                  value="JavaScript"
+                  defaultValue="JavaScript"
                 />
-                <label for="langs_javascript">JavaScript</label>
+                <label htmlFor="langs_javascript">JavaScript</label>
               </div>
               <div>
                 <input
                   type="checkbox"
                   name="langs"
                   id="langs_java"
-                  value="Java"
+                  defaultValue="Java"
                 />
-                <label for="langs_java">Java</label>
+                <label htmlFor="langs_java">Java</label>
               </div>
             </div>
-            <div className="adminEditProjectForm_form_col">
+            <div className="adminEditProjectForm__form_col">
               <div>
                 <input type="checkbox" name="langs" id="langs_c#" value="C#" />{" "}
-                <label for="langs_php">C#</label>
+                <label htmlFor="langs_php">C#</label>
               </div>
               <div>
                 <input
                   type="checkbox"
                   name="langs"
                   id="langs_php"
-                  value="PHP"
-                />{" "}
-                <label for="langs_php">PHP</label>
-              </div>{" "}
+                  defaultValue="PHP"
+                />
+                <label htmlFor="langs_php">PHP</label>
+              </div>
               <div>
                 <input type="checkbox" name="langs" id="langs_" value="C++" />
-                <label for="langs_php">C++</label>
+                <label htmlFor="langs_php">C++</label>
               </div>
             </div>
           </div>
           {/* Project Status */}
-          <div className="adminEditProjectForm_form_row">
-            <div className="adminEditProjectForm_form_col">
+          <div className="adminEditProjectForm__form_row">
+            <div className="adminEditProjectForm__form_col">
               <div>
                 <input type="checkbox" name="langs" id="langs_c#" value="C#" />
-                <label for="langs_php">Sign Up</label>
+                <label htmlFor="langs_php">Sign Up</label>
               </div>
               <div>
                 <input
@@ -155,24 +182,74 @@ const AdminEditProjectForm = (props) => {
                   id="langs_php"
                   value="PHP"
                 />{" "}
-                <label for="langs_php">Active</label>
+                <label htmlFor="langs_php">Active</label>
               </div>
             </div>
-            <div className="adminEditProjectForm_form_col">
+            <div className="adminEditProjectForm__form_col">
               <div>
                 <input type="checkbox" name="langs" id="langs_c#" value="C#" />
-                <label for="langs_php">Open Vote</label>
+                <label htmlFor="langs_php">Open Vote</label>
               </div>
               <div>
                 <input
                   type="checkbox"
                   name="langs"
                   id="langs_php"
-                  value="PHP"
-                />{" "}
-                <label for="langs_php">Completed</label>
+                  defaultValue="PHP"
+                />
+                <label htmlFor="langs_php">Completed</label>
               </div>
             </div>
+          </div>
+          <div className="member_data__container">
+            <div className="adminEditProjectForm__form_row">
+              <h3 className="adminEditProjectForm__section_header">
+                Member Data
+              </h3>
+            </div>
+            <div className="adminEditProjectForm__form_row">
+              <span className="adminEditProjectForm__section_sub_header">
+                Team Members Voted
+              </span>
+            </div>
+            <table>
+              <thead className="adminEditProjectForm__table_header">
+                <th>
+                  <h5>Name</h5>
+                </th>
+                <th>
+                  <h5>Slack Handle || Email</h5>
+                </th>
+              </thead>
+              <tbody>
+                {/* <tr>{getMembersVoted}</tr> */}
+                {getMembersVoted}
+                <tr className="adminEditProjectForm__horizontal_line"></tr>
+                {getMembersSignedUp}
+              </tbody>
+            </table>
+            <div className="adminEditProjectForm__form_row">
+              <span className="adminEditProjectForm__section_sub_header">
+                Team Members Signed Up
+              </span>
+            </div>
+            <table>
+              <thead className="adminEditProjectForm__table_header">
+                <th>
+                  <h5>Name</h5>
+                </th>
+                <th>
+                  <h5>GitHub Handle</h5>
+                </th>
+                <th>
+                  <h5>Email</h5>
+                </th>
+              </thead>
+              <tbody>
+                <tr className="adminEditProjectForm__horizontal_line"></tr>
+                {getMembersSignedUp}
+              </tbody>
+            </table>
           </div>
         </form>
       </div>

--- a/client/src/Components/AdminEditProjectForm/FormHeader.js
+++ b/client/src/Components/AdminEditProjectForm/FormHeader.js
@@ -1,0 +1,38 @@
+import React, { useState } from "react";
+
+export default function FormHeader(props) {
+  const { project } = props;
+
+  const [projectName, setProjectName] = useState({
+    value: project.project_name,
+    touched: "",
+  });
+  return (
+    <>
+      <div className="adminEditProjectForm__form_row adminEditProjectForm__header">
+        <div className="adminEditProjectForm__form_col adminEditProjectForm__header_title">
+          Project Details
+        </div>
+        <div className="adminEditProjectForm__form_col">
+          <button className="adminEditProjectForm__btn">Save As Draft</button>
+        </div>
+        <div className="adminEditProjectForm__form_col">
+          <button className="adminEditProjectForm__btn" type="submit">
+            Publish
+          </button>
+        </div>
+      </div>
+      <div className="adminEditProjectForm__form_row">
+        <label>Project Title</label>
+      </div>
+      <div className="adminEditProjectForm__form_row">
+        <input
+          type="text"
+          name="project_name"
+          defaultValue={projectName.value}
+          // onChange={}
+        />
+      </div>
+    </>
+  );
+}

--- a/client/src/Components/AdminEditProjectForm/FormHeader.js
+++ b/client/src/Components/AdminEditProjectForm/FormHeader.js
@@ -9,29 +9,34 @@ export default function FormHeader(props) {
   });
   return (
     <>
-      <div className="adminEditProjectForm__form_row adminEditProjectForm__header">
-        <div className="adminEditProjectForm__form_col adminEditProjectForm__header_title">
-          Project Details
+      <div className="adminEditProjectForm__header">
+        <div className="adminEditProjectForm__form_row adminEditProjectForm__toolbar">
+          <div className="adminEditProjectForm__form_col adminEditProjectForm__header_title">
+            Project Details
+          </div>
+          <div className="adminEditProjectForm__form_col adminEditProjectForm__btn_col">
+            <button className="adminEditProjectForm__btn">Save As Draft</button>
+          </div>
+          <div className="adminEditProjectForm__form_col adminEditProjectForm__btn_col">
+            <button className="adminEditProjectForm__btn" type="submit">
+              Publish
+            </button>
+          </div>
         </div>
-        <div className="adminEditProjectForm__form_col">
-          <button className="adminEditProjectForm__btn">Save As Draft</button>
+        <div className="adminEditProjectForm__project_info_container">
+          <div className="adminEditProjectForm__form_row adminEditProjectForm__project_title">
+            <label>Project Title:</label>
+          </div>
+          <div className="adminEditProjectForm__form_row">
+            <input
+              type="text"
+              name="project_name"
+              className="adminEditProjectForm__project_title_input"
+              defaultValue={projectName.value}
+              // onChange={}
+            />
+          </div>
         </div>
-        <div className="adminEditProjectForm__form_col">
-          <button className="adminEditProjectForm__btn" type="submit">
-            Publish
-          </button>
-        </div>
-      </div>
-      <div className="adminEditProjectForm__form_row">
-        <label>Project Title</label>
-      </div>
-      <div className="adminEditProjectForm__form_row">
-        <input
-          type="text"
-          name="project_name"
-          defaultValue={projectName.value}
-          // onChange={}
-        />
       </div>
     </>
   );

--- a/client/src/Components/AdminPanel/AdminPanel.js
+++ b/client/src/Components/AdminPanel/AdminPanel.js
@@ -25,7 +25,7 @@ export default function AdminPanel() {
         id=""
       />
       <div className="projects__items-project-name table-col">
-        <NavLink to={`/projects/${projects.project_id}`}>
+        <NavLink to={`/admin/projects/${projects.project_id}`}>
           {projects.project_name}
         </NavLink>
       </div>

--- a/client/src/Components/AdminPanelHeader/AdminPanelHeader.js
+++ b/client/src/Components/AdminPanelHeader/AdminPanelHeader.js
@@ -11,7 +11,7 @@ export default function AdminPanelHeader() {
       <Navbar expand="lg" className="admin-header--container">
         <Navbar.Brand href="/" className="admin-header--brand">
           <img
-            src="https://github.com/wwcodecolorado/returnship-project-voting/blob/kl-feature12-admin-panel-redesign/client/assets/icons/Home.png?raw=true"
+            src="https://github.com/wwcodecolorado/returnship-project-voting/blob/master/client/assets/icons/Home.png?raw=true"
             alt="Home Icon"
             className="admin-header--icon"
           />
@@ -22,7 +22,7 @@ export default function AdminPanelHeader() {
           <Nav className="">
             <Nav.Link href="/" className="">
               <img
-                src="https://github.com/wwcodecolorado/returnship-project-voting/blob/kl-feature12-admin-panel-redesign/client/assets/icons/login%20icon.png?raw=true"
+                src="https://github.com/wwcodecolorado/returnship-project-voting/blob/master/client/assets/icons/login%20icon.png?raw=true"
                 alt="Profile Icon"
                 className="admin-header--icon"
                 id="admin-header--profile-icon"

--- a/client/src/Components/AdminPanelHeader/AdminPanelHeader.js
+++ b/client/src/Components/AdminPanelHeader/AdminPanelHeader.js
@@ -20,7 +20,7 @@ export default function AdminPanelHeader() {
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav" className="justify-content-end">
           <Nav className="">
-            <Nav.Link href="/" className="">
+            <Nav.Link href="/admin" className="">
               <img
                 src="https://github.com/wwcodecolorado/returnship-project-voting/blob/master/client/assets/icons/login%20icon.png?raw=true"
                 alt="Profile Icon"

--- a/client/src/Components/AdminProjectDetails/AdminProjectDetails.js
+++ b/client/src/Components/AdminProjectDetails/AdminProjectDetails.js
@@ -6,9 +6,16 @@ import { GlobalContext } from "../../Context/GlobalContext";
 import AdminPanelHeader from "../AdminPanelHeader/AdminPanelHeader";
 import SideBar from "../SideBar/SideBar";
 
+// Import ReactBootstrap Components
+import Container from "react-bootstrap/Container";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import Form from "react-bootstrap/Form";
+import Button from "react-bootstrap/Button";
+
 export default function AdminProjectDetails(props) {
-  const projects = props;
-  console.log(projects);
+  const { project } = props;
+  console.log(project);
   return (
     <>
       <AdminPanelHeader />
@@ -17,7 +24,132 @@ export default function AdminProjectDetails(props) {
           <SideBar />
         </div>
         <div className="sideBar__col admin_project_details__container">
-          Hello World
+          <section className="">
+            <Container>
+              <Row>
+                <h2>{project.project_name}</h2>
+              </Row>
+
+              <Form>
+                {/* Short Description Input */}
+                <Form.Group as={Row} controlId="formShortDesc">
+                  <Col sm={3} className="d-flex align-items-end">
+                    <Form.Label>Short Description</Form.Label>
+                  </Col>
+
+                  <Col sm={8}>
+                    <Form.Control
+                      type="text"
+                      defaultValue={project.short_desc}
+                    />
+                  </Col>
+                </Form.Group>
+                {/* Long Description Input */}
+                <Form.Group as={Row} controlId="formLongDesc">
+                  <Col sm={3}>
+                    <Form.Label>Long Description</Form.Label>
+                  </Col>
+                  <Col sm={8}>
+                    <Form.Control
+                      as="textarea"
+                      rows="3"
+                      defaultValue={project.long_desc}
+                    />
+                  </Col>
+                </Form.Group>
+                {/* Contact Input */}
+                <Form.Group as={Row} controlId="formContact">
+                  <Col sm={3} className="d-flex align-items-end">
+                    <Form.Label>Contact</Form.Label>
+                  </Col>
+
+                  <Col sm={8}>
+                    <Form.Control type="text" defaultValue={project.contact} />
+                  </Col>
+                </Form.Group>
+                {/* Company Input */}
+                <Form.Group as={Row} controlId="formCompany">
+                  <Col sm={3} className="d-flex align-items-end">
+                    <Form.Label>Company</Form.Label>
+                  </Col>
+
+                  <Col sm={8}>
+                    <Form.Control type="text" defaultValue={project.company} />
+                  </Col>
+                </Form.Group>
+                {/* Tech Stack Input */}
+                <Form.Group as={Row} controlId="formContact">
+                  <Col sm={3} className="d-flex align-items-end">
+                    <Form.Label>Tech Stack</Form.Label>
+                  </Col>
+                  <Col sm={8}>
+                    <Form.Control as="select" multiple>
+                      <option>JavaScript</option>
+                      <option>Python</option>
+                      <option>3</option>
+                      <option>4</option>
+                      <option>5</option>
+                    </Form.Control>
+                    <Form.Text className="text-muted">
+                      Use command on a mac or the space-bar on a windows machine
+                      to select multiple technologies.
+                    </Form.Text>
+                  </Col>
+                </Form.Group>
+                {/* Status Input */}
+                <Form.Group as={Row} controlId="formStatus">
+                  <Col sm={3} className="d-flex align-items-start">
+                    <Form.Label>Status</Form.Label>
+                  </Col>
+
+                  <Col sm={8} className="d-flex align-items-start">
+                    <fieldset>
+                      <Form.Check
+                        type="radio"
+                        label="Open to New Members"
+                        name="formHorizontalRadios"
+                        id="formHorizontalRadios2"
+                        className="d-flex align-items-center"
+                      />
+                      <Form.Check
+                        type="radio"
+                        label="In Development"
+                        name="formHorizontalRadios"
+                        id="formHorizontalRadios3"
+                        className="d-flex align-items-center"
+                      />
+                      <Form.Check
+                        type="radio"
+                        label="Closed"
+                        name="formHorizontalRadios"
+                        id="formHorizontalRadios3"
+                        className="d-flex align-items-center"
+                      />
+                    </fieldset>
+                  </Col>
+                </Form.Group>
+                {/* Interested Team Members Input */}
+                <Form.Group as={Row} controlId="formIntMem">
+                  <Col sm={3} className="d-flex align-items-end">
+                    <Form.Label>Interested Team Members</Form.Label>
+                  </Col>
+                  <Col sm={8}></Col>
+                </Form.Group>
+                {/* Team Members */}
+                <Form.Group as={Row} controlId="formIntMem">
+                  <Col sm={3} className="d-flex align-items-end">
+                    <Form.Label>Team Members</Form.Label>
+                  </Col>
+                  <Col sm={8}></Col>
+                </Form.Group>
+                <Row className="d-flex justify-content-end">
+                  <Button type="submit" className="mb-2">
+                    Submit
+                  </Button>
+                </Row>
+              </Form>
+            </Container>
+          </section>
         </div>
       </div>
     </>

--- a/client/src/Components/AdminProjectDetails/AdminProjectDetails.js
+++ b/client/src/Components/AdminProjectDetails/AdminProjectDetails.js
@@ -1,21 +1,15 @@
 // Import React Packages
 import React, { useContext } from "react";
-import { GlobalContext } from "../../Context/GlobalContext";
+
 
 // Import Custom Components
 import AdminPanelHeader from "../AdminPanelHeader/AdminPanelHeader";
 import SideBar from "../SideBar/SideBar";
-
-// Import ReactBootstrap Components
-import Container from "react-bootstrap/Container";
-import Row from "react-bootstrap/Row";
-import Col from "react-bootstrap/Col";
-import Form from "react-bootstrap/Form";
-import Button from "react-bootstrap/Button";
+import AdminEditProjectForm from "../AdminEditProjectForm/AdminEditProjectForm";
 
 export default function AdminProjectDetails(props) {
   const { project } = props;
-  console.log(project);
+  console.log(`project_props:`, project);
   return (
     <>
       <AdminPanelHeader />
@@ -24,134 +18,137 @@ export default function AdminProjectDetails(props) {
           <SideBar />
         </div>
         <div className="sideBar__col admin_project_details__container">
-          <section className="">
-            <Container>
-              <Row>
-                <h2>{project.project_name}</h2>
-              </Row>
-
-              <Form>
-                {/* Short Description Input */}
-                <Form.Group as={Row} controlId="formShortDesc">
-                  <Col sm={3} className="d-flex align-items-end">
-                    <Form.Label>Short Description</Form.Label>
-                  </Col>
-
-                  <Col sm={8}>
-                    <Form.Control
-                      type="text"
-                      defaultValue={project.short_desc}
-                    />
-                  </Col>
-                </Form.Group>
-                {/* Long Description Input */}
-                <Form.Group as={Row} controlId="formLongDesc">
-                  <Col sm={3}>
-                    <Form.Label>Long Description</Form.Label>
-                  </Col>
-                  <Col sm={8}>
-                    <Form.Control
-                      as="textarea"
-                      rows="3"
-                      defaultValue={project.long_desc}
-                    />
-                  </Col>
-                </Form.Group>
-                {/* Contact Input */}
-                <Form.Group as={Row} controlId="formContact">
-                  <Col sm={3} className="d-flex align-items-end">
-                    <Form.Label>Contact</Form.Label>
-                  </Col>
-
-                  <Col sm={8}>
-                    <Form.Control type="text" defaultValue={project.contact} />
-                  </Col>
-                </Form.Group>
-                {/* Company Input */}
-                <Form.Group as={Row} controlId="formCompany">
-                  <Col sm={3} className="d-flex align-items-end">
-                    <Form.Label>Company</Form.Label>
-                  </Col>
-
-                  <Col sm={8}>
-                    <Form.Control type="text" defaultValue={project.company} />
-                  </Col>
-                </Form.Group>
-                {/* Tech Stack Input */}
-                <Form.Group as={Row} controlId="formContact">
-                  <Col sm={3} className="d-flex align-items-end">
-                    <Form.Label>Tech Stack</Form.Label>
-                  </Col>
-                  <Col sm={8}>
-                    <Form.Control as="select" multiple>
-                      <option>JavaScript</option>
-                      <option>Python</option>
-                      <option>3</option>
-                      <option>4</option>
-                      <option>5</option>
-                    </Form.Control>
-                    <Form.Text className="text-muted">
-                      Use command on a mac or the space-bar on a windows machine
-                      to select multiple technologies.
-                    </Form.Text>
-                  </Col>
-                </Form.Group>
-                {/* Status Input */}
-                <Form.Group as={Row} controlId="formStatus">
-                  <Col sm={3} className="d-flex align-items-start">
-                    <Form.Label>Status</Form.Label>
-                  </Col>
-
-                  <Col sm={8} className="d-flex align-items-start">
-                    <fieldset>
-                      <Form.Check
-                        type="radio"
-                        label="Open to New Members"
-                        name="formHorizontalRadios"
-                        id="formHorizontalRadios2"
-                        className="d-flex align-items-center"
-                      />
-                      <Form.Check
-                        type="radio"
-                        label="In Development"
-                        name="formHorizontalRadios"
-                        id="formHorizontalRadios3"
-                        className="d-flex align-items-center"
-                      />
-                      <Form.Check
-                        type="radio"
-                        label="Closed"
-                        name="formHorizontalRadios"
-                        id="formHorizontalRadios3"
-                        className="d-flex align-items-center"
-                      />
-                    </fieldset>
-                  </Col>
-                </Form.Group>
-                {/* Interested Team Members Input */}
-                <Form.Group as={Row} controlId="formIntMem">
-                  <Col sm={3} className="d-flex align-items-end">
-                    <Form.Label>Interested Team Members</Form.Label>
-                  </Col>
-                  <Col sm={8}></Col>
-                </Form.Group>
-                {/* Team Members */}
-                <Form.Group as={Row} controlId="formIntMem">
-                  <Col sm={3} className="d-flex align-items-end">
-                    <Form.Label>Team Members</Form.Label>
-                  </Col>
-                  <Col sm={8}></Col>
-                </Form.Group>
-                <Row className="d-flex justify-content-end">
-                  <Button type="submit" className="mb-2">
-                    Submit
-                  </Button>
-                </Row>
-              </Form>
-            </Container>
-          </section>
+          <AdminEditProjectForm
+          project={project}
+          // key={project.project_id} // TODO: Remove?
+          />
         </div>
       </div>
     </>
   );
+  // }
 }
+
+// {/* <section className="">
+//   <Container>
+//     <Row>
+//       <h2>{project.project_name}</h2>
+//     </Row>
+
+//     <Form>
+//       {/* Short Description Input */}
+//       <Form.Group as={Row} controlId="formShortDesc">
+//         <Col sm={3} className="d-flex align-items-end">
+//           <Form.Label>Short Description</Form.Label>
+//         </Col>
+
+//         <Col sm={8}>
+//           <Form.Control type="text" defaultValue={project.short_desc} />
+//         </Col>
+//       </Form.Group>
+//       {/* Long Description Input */}
+//       <Form.Group as={Row} controlId="formLongDesc">
+//         <Col sm={3}>
+//           <Form.Label>Long Description</Form.Label>
+//         </Col>
+//         <Col sm={8}>
+//           <Form.Control
+//             as="textarea"
+//             rows="3"
+//             defaultValue={project.long_desc}
+//           />
+//         </Col>
+//       </Form.Group>
+//       {/* Contact Input */}
+//       <Form.Group as={Row} controlId="formContact">
+//         <Col sm={3} className="d-flex align-items-end">
+//           <Form.Label>Contact</Form.Label>
+//         </Col>
+
+//         <Col sm={8}>
+//           <Form.Control type="text" defaultValue={project.contact} />
+//         </Col>
+//       </Form.Group>
+//       {/* Company Input */}
+//       <Form.Group as={Row} controlId="formCompany">
+//         <Col sm={3} className="d-flex align-items-end">
+//           <Form.Label>Company</Form.Label>
+//         </Col>
+
+//         <Col sm={8}>
+//           <Form.Control type="text" defaultValue={project.company} />
+//         </Col>
+//       </Form.Group>
+//       {/* Tech Stack Input */}
+//       <Form.Group as={Row} controlId="formContact">
+//         <Col sm={3} className="d-flex align-items-end">
+//           <Form.Label>Tech Stack</Form.Label>
+//         </Col>
+//         <Col sm={8}>
+//           <Form.Control as="select" multiple>
+//             <option>JavaScript</option>
+//             <option>Python</option>
+//             <option>3</option>
+//             <option>4</option>
+//             <option>5</option>
+//           </Form.Control>
+//           <Form.Text className="text-muted">
+//             Use command on a mac or the space-bar on a windows machine to select
+//             multiple technologies.
+//           </Form.Text>
+//         </Col>
+//       </Form.Group>
+//       {/* Status Input */}
+//       <Form.Group as={Row} controlId="formStatus">
+//         <Col sm={3} className="d-flex align-items-start">
+//           <Form.Label>Status</Form.Label>
+//         </Col>
+
+//         <Col sm={8} className="d-flex align-items-start">
+//           <fieldset>
+//             <Form.Check
+//               type="radio"
+//               label="Open to New Members"
+//               name="formHorizontalRadios"
+//               id="formHorizontalRadios2"
+//               className="d-flex align-items-center"
+//             />
+//             <Form.Check
+//               type="radio"
+//               label="In Development"
+//               name="formHorizontalRadios"
+//               id="formHorizontalRadios3"
+//               className="d-flex align-items-center"
+//             />
+//             <Form.Check
+//               type="radio"
+//               label="Closed"
+//               name="formHorizontalRadios"
+//               id="formHorizontalRadios3"
+//               className="d-flex align-items-center"
+//             />
+//           </fieldset>
+//         </Col>
+//       </Form.Group>
+//       {/* Interested Team Members Input */}
+//       <Form.Group as={Row} controlId="formIntMem">
+//         <Col sm={3} className="d-flex align-items-end">
+//           <Form.Label>Interested Team Members</Form.Label>
+//         </Col>
+//         <Col sm={8}></Col>
+//       </Form.Group>
+//       {/* Team Members */}
+//       <Form.Group as={Row} controlId="formIntMem">
+//         <Col sm={3} className="d-flex align-items-end">
+//           <Form.Label>Team Members</Form.Label>
+//         </Col>
+//         <Col sm={8}></Col>
+//       </Form.Group>
+//       <Row className="d-flex justify-content-end">
+//         <Button type="submit" className="mb-2">
+//           Submit
+//         </Button>
+//       </Row>
+//     </Form>
+//   </Container>
+// </section>; */}

--- a/client/src/Components/AdminProjectDetails/AdminProjectDetails.js
+++ b/client/src/Components/AdminProjectDetails/AdminProjectDetails.js
@@ -1,7 +1,6 @@
 // Import React Packages
 import React, { useContext } from "react";
 
-
 // Import Custom Components
 import AdminPanelHeader from "../AdminPanelHeader/AdminPanelHeader";
 import SideBar from "../SideBar/SideBar";
@@ -13,20 +12,19 @@ export default function AdminProjectDetails(props) {
   return (
     <>
       <AdminPanelHeader />
-      <div className="sideBar__row admin_project_details">
-        <div className="sideBar__col">
+      <div className="admin_project_details__sideBar_row admin_project_details__container">
+        <div className="admin_project_details__sideBar_col">
           <SideBar />
         </div>
-        <div className="sideBar__col admin_project_details__container">
+        <div className="admin_project_details__sideBar_col admin_project_details__form_container">
           <AdminEditProjectForm
-          project={project}
-          // key={project.project_id} // TODO: Remove?
+            project={project}
+            // key={project.project_id} // TODO: Remove?
           />
         </div>
       </div>
     </>
   );
-  // }
 }
 
 // {/* <section className="">

--- a/client/src/Components/AdminProjectDetails/AdminProjectDetails.js
+++ b/client/src/Components/AdminProjectDetails/AdminProjectDetails.js
@@ -1,0 +1,23 @@
+// Import React Packages
+import React, { useContext } from "react";
+import { GlobalContext } from "../../Context/GlobalContext";
+
+// Import Custom Components
+import AdminPanelHeader from "../AdminPanelHeader/AdminPanelHeader";
+import SideBar from "../SideBar/SideBar";
+
+export default function AdminProjectDetails(props) {
+  const projects = props;
+  console.log(projects);
+  return (
+    <>
+      <AdminPanelHeader />
+      <div className="row">
+        <div className="col">
+          <SideBar />
+        </div>
+        <div className="col">Hello World</div>
+      </div>
+    </>
+  );
+}

--- a/client/src/Components/AdminProjectDetails/AdminProjectDetails.js
+++ b/client/src/Components/AdminProjectDetails/AdminProjectDetails.js
@@ -12,11 +12,13 @@ export default function AdminProjectDetails(props) {
   return (
     <>
       <AdminPanelHeader />
-      <div className="row">
-        <div className="col">
+      <div className="sideBar__row admin_project_details">
+        <div className="sideBar__col">
           <SideBar />
         </div>
-        <div className="col">Hello World</div>
+        <div className="sideBar__col admin_project_details__container">
+          Hello World
+        </div>
       </div>
     </>
   );

--- a/client/src/Components/SideBar/SideBar.js
+++ b/client/src/Components/SideBar/SideBar.js
@@ -11,7 +11,7 @@ const SideBar = () => (
             <li>
               <NavLink className="sideBar--link" exact to="/admin">
                 <img
-                  src="https://github.com/wwcodecolorado/returnship-project-voting/blob/kl-feature12-admin-panel-redesign/client/assets/icons/archives.png?raw=true"
+                  src="https://github.com/wwcodecolorado/returnship-project-voting/blob/master/client/assets/icons/archives.png?raw=true"
                   alt="Archives Icon"
                   className="admin-header--icon"
                   id="admin-header--archives-icon"
@@ -22,7 +22,7 @@ const SideBar = () => (
             <li>
               <NavLink className="sideBar--link" exact to="/admin">
                 <img
-                  src="https://github.com/wwcodecolorado/returnship-project-voting/blob/kl-feature12-admin-panel-redesign/client/assets/icons/user-icon.png?raw=true"
+                  src="https://github.com/wwcodecolorado/returnship-project-voting/blob/master/client/assets/icons/user-icon.png?raw=true"
                   alt="User Icon"
                   className="admin-header--icon"
                 />

--- a/client/src/STORE.js
+++ b/client/src/STORE.js
@@ -79,22 +79,22 @@ export default {
           voter_email: "Kim@aol.com",
         },
         {
-          table_vote_id: 1,
-          project_id: 3,
+          table_vote_id: 3,
+          project_id: 2,
           voter_name: "Kathy",
           voter_slack_name: "Kathy",
           voter_email: "Kathy@aol.com",
         },
         {
-          table_vote_id: 2,
-          project_id: 4,
+          table_vote_id: 4,
+          project_id: 2,
           voter_name: "Kim",
           voter_slack_name: "Kim",
           voter_email: "Kim@aol.com",
         },
         {
-          table_vote_id: 2,
-          project_id: 5,
+          table_vote_id: 5,
+          project_id: 2,
           voter_name: "Kim",
           voter_slack_name: "Kim",
           voter_email: "Kim@aol.com",
@@ -102,15 +102,15 @@ export default {
       ],
       table_signup: [
         {
-          signup_id: 1,
-          project_id: 1,
+          signup_id: 6,
+          project_id: 2,
           signup_name: "Kathy",
           signup_github_name: "CodeMeKathy",
           signup_email: "Kathy@aol.com",
         },
         {
-          signup_id: 2,
-          project_id: 1,
+          signup_id: 7,
+          project_id: 2,
           signup_name: "Kim",
           signup_github_name: "KimSlim",
           signup_email: "Kim@aol.com",
@@ -151,14 +151,14 @@ export default {
       table_signup: [
         {
           signup_id: 1,
-          project_id: 1,
+          project_id: 3,
           signup_name: "Kathy",
           signup_github_name: "CodeMeKathy",
           signup_email: "Kathy@aol.com",
         },
         {
           signup_id: 2,
-          project_id: 1,
+          project_id: 3,
           signup_name: "Kim",
           signup_github_name: "KimSlim",
           signup_email: "Kim@aol.com",
@@ -199,14 +199,14 @@ export default {
       table_signup: [
         {
           signup_id: 1,
-          project_id: 1,
+          project_id: 4,
           signup_name: "Kathy",
           signup_github_name: "CodeMeKathy",
           signup_email: "Kathy@aol.com",
         },
         {
           signup_id: 2,
-          project_id: 1,
+          project_id: 4,
           signup_name: "Kim",
           signup_github_name: "KimSlim",
           signup_email: "Kim@aol.com",
@@ -247,14 +247,14 @@ export default {
       table_signup: [
         {
           signup_id: 1,
-          project_id: 1,
+          project_id: 5,
           signup_name: "Kathy",
           signup_github_name: "CodeMeKathy",
           signup_email: "Kathy@aol.com",
         },
         {
           signup_id: 2,
-          project_id: 1,
+          project_id: 5,
           signup_name: "Kim",
           signup_github_name: "KimSlim",
           signup_email: "Kim@aol.com",
@@ -295,14 +295,14 @@ export default {
       table_signup: [
         {
           signup_id: 1,
-          project_id: 1,
+          project_id: 6,
           signup_name: "Kathy",
           signup_github_name: "CodeMeKathy",
           signup_email: "Kathy@aol.com",
         },
         {
           signup_id: 2,
-          project_id: 1,
+          project_id: 6,
           signup_name: "Kim",
           signup_github_name: "KimSlim",
           signup_email: "Kim@aol.com",
@@ -343,14 +343,14 @@ export default {
       table_signup: [
         {
           signup_id: 1,
-          project_id: 1,
+          project_id: 7,
           signup_name: "Kathy",
           signup_github_name: "CodeMeKathy",
           signup_email: "Kathy@aol.com",
         },
         {
           signup_id: 2,
-          project_id: 1,
+          project_id: 7,
           signup_name: "Kim",
           signup_github_name: "KimSlim",
           signup_email: "Kim@aol.com",
@@ -391,14 +391,14 @@ export default {
       table_signup: [
         {
           signup_id: 1,
-          project_id: 1,
+          project_id: 8,
           signup_name: "Kathy",
           signup_github_name: "CodeMeKathy",
           signup_email: "Kathy@aol.com",
         },
         {
           signup_id: 2,
-          project_id: 1,
+          project_id: 8,
           signup_name: "Kim",
           signup_github_name: "KimSlim",
           signup_email: "Kim@aol.com",
@@ -439,14 +439,14 @@ export default {
       table_signup: [
         {
           signup_id: 1,
-          project_id: 1,
+          project_id: 9,
           signup_name: "Kathy",
           signup_github_name: "CodeMeKathy",
           signup_email: "Kathy@aol.com",
         },
         {
           signup_id: 2,
-          project_id: 1,
+          project_id: 9,
           signup_name: "Kim",
           signup_github_name: "KimSlim",
           signup_email: "Kim@aol.com",
@@ -487,14 +487,14 @@ export default {
       table_signup: [
         {
           signup_id: 1,
-          project_id: 1,
+          project_id: 10,
           signup_name: "Kathy",
           signup_github_name: "CodeMeKathy",
           signup_email: "Kathy@aol.com",
         },
         {
           signup_id: 2,
-          project_id: 1,
+          project_id: 10,
           signup_name: "Kim",
           signup_github_name: "KimSlim",
           signup_email: "Kim@aol.com",

--- a/client/src/STORE.js
+++ b/client/src/STORE.js
@@ -3,7 +3,8 @@ export default {
     {
       project_id: 1,
       project_name: "Career Returnship App",
-      project_desc: "This is a really long description for Project 1",
+      project_desc:
+        "This is a really long description for Project 1. Lorem ipsum dolor sit amet, sit illud posse porro at, ex has regione sententiae, adhuc habemus vis in. Eos id suas moderatius, in vero mutat omnesque sed, ex graeci fabulas ius. Aeque tation appellantur ad nec, cum reque congue te. Ei nec aeque dicunt, per te sale indoctum mnesarchum. Mea lucilius disputando cu.",
       client_name: "John Doe",
       client_email: "johndoe@gmail.com",
       client_company: "Doe Enterprises",
@@ -14,13 +15,16 @@ export default {
       sign_up: 0,
       vote: 0,
       date: "10/20/2020",
+      members_voted: "[{name: Jane Doe, contact_info: janedoe@gmail.com}]",
+      members_signed_up: "[{name: Jane Doe, contact_info: janedoe@gmail.com}]",
     },
     {
       project_id: 2,
       project_name: "ProjectHub App",
-      project_desc: "This is a really long description for Project 2",
-      client_name: "John Doe",
-      client_email: "johndoe@gmail.com",
+      project_desc:
+        "This is a really long description for Project 2. Causae ornatus epicuri cu ius. Et nam purto deterruisset, quo mediocrem expetenda theophrastus ea. Usu in quod libris ocurreret, everti suscipit ex qui. In harum legimus repudiandae pro, qui ea alia elit maiorum, vix no soluta adolescens.",
+      client_name: "Steve Madden",
+      client_email: "steve_madden@gmail.com",
       client_company: "Doe Enterprises",
       client_phone: "3035551212",
       max_team_members: 5,
@@ -33,9 +37,10 @@ export default {
     {
       project_id: 3,
       project_name: "Delish App",
-      project_desc: "This is a really long description for Project 3",
-      client_name: "John Doe",
-      client_email: "johndoe@gmail.com",
+      project_desc:
+        "This is a really long description for Project 3. Causae ornatus epicuri cu ius. Et nam purto deterruisset, quo mediocrem expetenda theophrastus ea. Usu in quod libris ocurreret, everti suscipit ex qui. In harum legimus repudiandae pro, qui ea alia elit maiorum, vix no soluta adolescens.",
+      client_name: "Sally White",
+      client_email: "sally_white@gmail.com",
       client_company: "Doe Enterprises",
       client_phone: "3035551212",
       max_team_members: 5,
@@ -48,7 +53,8 @@ export default {
     {
       project_id: 4,
       project_name: "Special App",
-      project_desc: "This is a really long description for Project 4",
+      project_desc:
+        "This is a really long description for Project 4. Causae ornatus epicuri cu ius. Et nam purto deterruisset, quo mediocrem expetenda theophrastus ea. Usu in quod libris ocurreret, everti suscipit ex qui. In harum legimus repudiandae pro, qui ea alia elit maiorum, vix no soluta adolescens.",
       client_name: "John Doe",
       client_email: "johndoe@gmail.com",
       client_company: "Doe Enterprises",
@@ -63,7 +69,8 @@ export default {
     {
       project_id: 5,
       project_name: "New Project 5",
-      project_desc: "This is a really long description for Project 5",
+      project_desc:
+        "This is a really long description for Project 5. Causae ornatus epicuri cu ius. Et nam purto deterruisset, quo mediocrem expetenda theophrastus ea. Usu in quod libris ocurreret, everti suscipit ex qui. In harum legimus repudiandae pro, qui ea alia elit maiorum, vix no soluta adolescens.",
       client_name: "John Doe",
       client_email: "johndoe@gmail.com",
       client_company: "Doe Enterprises",
@@ -78,7 +85,8 @@ export default {
     {
       project_id: 6,
       project_name: "New Project 6",
-      project_desc: "This is a really long description for Project 6",
+      project_desc:
+        "This is a really long description for Project 6. Causae ornatus epicuri cu ius. Et nam purto deterruisset, quo mediocrem expetenda theophrastus ea. Usu in quod libris ocurreret, everti suscipit ex qui. In harum legimus repudiandae pro, qui ea alia elit maiorum, vix no soluta adolescens.",
       client_name: "John Doe",
       client_email: "johndoe@gmail.com",
       client_company: "Doe Enterprises",
@@ -93,7 +101,8 @@ export default {
     {
       project_id: 7,
       project_name: "New Project 7",
-      project_desc: "This is a really long description for Project 7",
+      project_desc:
+        "This is a really long description for Project 7. Causae ornatus epicuri cu ius. Et nam purto deterruisset, quo mediocrem expetenda theophrastus ea. Usu in quod libris ocurreret, everti suscipit ex qui. In harum legimus repudiandae pro, qui ea alia elit maiorum, vix no soluta adolescens.",
       client_name: "John Doe",
       client_email: "johndoe@gmail.com",
       client_company: "Doe Enterprises",
@@ -108,7 +117,8 @@ export default {
     {
       project_id: 8,
       project_name: "New Project 8",
-      project_desc: "This is a really long description for Project 8",
+      project_desc:
+        "This is a really long description for Project 8. Causae ornatus epicuri cu ius. Et nam purto deterruisset, quo mediocrem expetenda theophrastus ea. Usu in quod libris ocurreret, everti suscipit ex qui. In harum legimus repudiandae pro, qui ea alia elit maiorum, vix no soluta adolescens.",
       client_name: "John Doe",
       client_email: "johndoe@gmail.com",
       client_company: "Doe Enterprises",
@@ -123,7 +133,8 @@ export default {
     {
       project_id: 9,
       project_name: "New Project 9",
-      project_desc: "This is a really long description for Project 9",
+      project_desc:
+        "This is a really long description for Project 9. Causae ornatus epicuri cu ius. Et nam purto deterruisset, quo mediocrem expetenda theophrastus ea. Usu in quod libris ocurreret, everti suscipit ex qui. In harum legimus repudiandae pro, qui ea alia elit maiorum, vix no soluta adolescens.",
       client_name: "John Doe",
       client_email: "johndoe@gmail.com",
       client_company: "Doe Enterprises",
@@ -138,7 +149,8 @@ export default {
     {
       project_id: 10,
       project_name: "New Project 10",
-      project_desc: "This is a really long description for Project 10",
+      project_desc:
+        "This is a really long description for Project 10. Causae ornatus epicuri cu ius. Et nam purto deterruisset, quo mediocrem expetenda theophrastus ea. Usu in quod libris ocurreret, everti suscipit ex qui. In harum legimus repudiandae pro, qui ea alia elit maiorum, vix no soluta adolescens.",
       client_name: "John Doe",
       client_email: "johndoe@gmail.com",
       client_company: "Doe Enterprises",

--- a/client/src/STORE.js
+++ b/client/src/STORE.js
@@ -15,8 +15,38 @@ export default {
       sign_up: 0,
       vote: 0,
       date: "10/20/2020",
-      members_voted: "[{name: Jane Doe, contact_info: janedoe@gmail.com}]",
-      members_signed_up: "[{name: Jane Doe, contact_info: janedoe@gmail.com}]",
+      table_vote: [
+        {
+          table_vote_id: 1,
+          project_id: 1,
+          voter_name: "Kathy",
+          voter_slack_name: "CodeMeKathy",
+          voter_email: "Kathy@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 1,
+          voter_name: "Kim",
+          voter_slack_name: "KimSlim",
+          voter_email: "Kim@aol.com",
+        },
+      ],
+      table_signup: [
+        {
+          signup_id: 1,
+          project_id: 1,
+          signup_name: "Kathy",
+          signup_github_name: "CodeMeKathy",
+          signup_email: "Kathy@aol.com",
+        },
+        {
+          signup_id: 2,
+          project_id: 1,
+          signup_name: "Kim",
+          signup_github_name: "KimSlim",
+          signup_email: "Kim@aol.com",
+        },
+      ],
     },
     {
       project_id: 2,
@@ -33,6 +63,59 @@ export default {
       sign_up: 3,
       vote: 5,
       date: "10/20/2020",
+      table_vote: [
+        {
+          table_vote_id: 1,
+          project_id: 2,
+          voter_name: "Kathy",
+          voter_slack_name: "Kathy",
+          voter_email: "Kathy@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 2,
+          voter_name: "Kim",
+          voter_slack_name: "Kim",
+          voter_email: "Kim@aol.com",
+        },
+        {
+          table_vote_id: 1,
+          project_id: 3,
+          voter_name: "Kathy",
+          voter_slack_name: "Kathy",
+          voter_email: "Kathy@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 4,
+          voter_name: "Kim",
+          voter_slack_name: "Kim",
+          voter_email: "Kim@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 5,
+          voter_name: "Kim",
+          voter_slack_name: "Kim",
+          voter_email: "Kim@aol.com",
+        },
+      ],
+      table_signup: [
+        {
+          signup_id: 1,
+          project_id: 1,
+          signup_name: "Kathy",
+          signup_github_name: "CodeMeKathy",
+          signup_email: "Kathy@aol.com",
+        },
+        {
+          signup_id: 2,
+          project_id: 1,
+          signup_name: "Kim",
+          signup_github_name: "KimSlim",
+          signup_email: "Kim@aol.com",
+        },
+      ],
     },
     {
       project_id: 3,
@@ -49,6 +132,38 @@ export default {
       sign_up: 2,
       vote: 4,
       date: "10/20/2020",
+      table_vote: [
+        {
+          table_vote_id: 1,
+          project_id: 3,
+          voter_name: "Kathy",
+          voter_slack_name: "Kathy",
+          voter_email: "Kathy@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 3,
+          voter_name: "Kim",
+          voter_slack_name: "Kim",
+          voter_email: "Kim@aol.com",
+        },
+      ],
+      table_signup: [
+        {
+          signup_id: 1,
+          project_id: 1,
+          signup_name: "Kathy",
+          signup_github_name: "CodeMeKathy",
+          signup_email: "Kathy@aol.com",
+        },
+        {
+          signup_id: 2,
+          project_id: 1,
+          signup_name: "Kim",
+          signup_github_name: "KimSlim",
+          signup_email: "Kim@aol.com",
+        },
+      ],
     },
     {
       project_id: 4,
@@ -65,6 +180,38 @@ export default {
       sign_up: 2,
       vote: 4,
       date: "10/20/2020",
+      table_vote: [
+        {
+          table_vote_id: 1,
+          project_id: 4,
+          voter_name: "Kathy",
+          voter_slack_name: "Kathy",
+          voter_email: "Kathy@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 4,
+          voter_name: "Kim",
+          voter_slack_name: "Kim",
+          voter_email: "Kim@aol.com",
+        },
+      ],
+      table_signup: [
+        {
+          signup_id: 1,
+          project_id: 1,
+          signup_name: "Kathy",
+          signup_github_name: "CodeMeKathy",
+          signup_email: "Kathy@aol.com",
+        },
+        {
+          signup_id: 2,
+          project_id: 1,
+          signup_name: "Kim",
+          signup_github_name: "KimSlim",
+          signup_email: "Kim@aol.com",
+        },
+      ],
     },
     {
       project_id: 5,
@@ -81,6 +228,38 @@ export default {
       sign_up: 2,
       vote: 4,
       date: "10/20/2020",
+      table_vote: [
+        {
+          table_vote_id: 1,
+          project_id: 5,
+          voter_name: "Kathy",
+          voter_slack_name: "Kathy",
+          voter_email: "Kathy@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 5,
+          voter_name: "Kim",
+          voter_slack_name: "Kim",
+          voter_email: "Kim@aol.com",
+        },
+      ],
+      table_signup: [
+        {
+          signup_id: 1,
+          project_id: 1,
+          signup_name: "Kathy",
+          signup_github_name: "CodeMeKathy",
+          signup_email: "Kathy@aol.com",
+        },
+        {
+          signup_id: 2,
+          project_id: 1,
+          signup_name: "Kim",
+          signup_github_name: "KimSlim",
+          signup_email: "Kim@aol.com",
+        },
+      ],
     },
     {
       project_id: 6,
@@ -97,6 +276,38 @@ export default {
       sign_up: 2,
       vote: 4,
       date: "10/20/2020",
+      table_vote: [
+        {
+          table_vote_id: 1,
+          project_id: 6,
+          voter_name: "Kathy",
+          voter_slack_name: "Kathy",
+          voter_email: "Kathy@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 6,
+          voter_name: "Kim",
+          voter_slack_name: "Kim",
+          voter_email: "Kim@aol.com",
+        },
+      ],
+      table_signup: [
+        {
+          signup_id: 1,
+          project_id: 1,
+          signup_name: "Kathy",
+          signup_github_name: "CodeMeKathy",
+          signup_email: "Kathy@aol.com",
+        },
+        {
+          signup_id: 2,
+          project_id: 1,
+          signup_name: "Kim",
+          signup_github_name: "KimSlim",
+          signup_email: "Kim@aol.com",
+        },
+      ],
     },
     {
       project_id: 7,
@@ -113,6 +324,38 @@ export default {
       sign_up: 2,
       vote: 4,
       date: "10/20/2020",
+      table_vote: [
+        {
+          table_vote_id: 1,
+          project_id: 7,
+          voter_name: "Kathy",
+          voter_slack_name: "Kathy",
+          voter_email: "Kathy@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 7,
+          voter_name: "Kim",
+          voter_slack_name: "Kim",
+          voter_email: "Kim@aol.com",
+        },
+      ],
+      table_signup: [
+        {
+          signup_id: 1,
+          project_id: 1,
+          signup_name: "Kathy",
+          signup_github_name: "CodeMeKathy",
+          signup_email: "Kathy@aol.com",
+        },
+        {
+          signup_id: 2,
+          project_id: 1,
+          signup_name: "Kim",
+          signup_github_name: "KimSlim",
+          signup_email: "Kim@aol.com",
+        },
+      ],
     },
     {
       project_id: 8,
@@ -129,6 +372,38 @@ export default {
       sign_up: 2,
       vote: 4,
       date: "10/20/2020",
+      table_vote: [
+        {
+          table_vote_id: 1,
+          project_id: 8,
+          voter_name: "Kathy",
+          voter_slack_name: "Kathy",
+          voter_email: "Kathy@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 8,
+          voter_name: "Kim",
+          voter_slack_name: "Kim",
+          voter_email: "Kim@aol.com",
+        },
+      ],
+      table_signup: [
+        {
+          signup_id: 1,
+          project_id: 1,
+          signup_name: "Kathy",
+          signup_github_name: "CodeMeKathy",
+          signup_email: "Kathy@aol.com",
+        },
+        {
+          signup_id: 2,
+          project_id: 1,
+          signup_name: "Kim",
+          signup_github_name: "KimSlim",
+          signup_email: "Kim@aol.com",
+        },
+      ],
     },
     {
       project_id: 9,
@@ -145,6 +420,38 @@ export default {
       sign_up: 2,
       vote: 4,
       date: "10/20/2020",
+      table_vote: [
+        {
+          table_vote_id: 1,
+          project_id: 9,
+          voter_name: "Kathy",
+          voter_slack_name: "Kathy",
+          voter_email: "Kathy@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 9,
+          voter_name: "Kim",
+          voter_slack_name: "Kim",
+          voter_email: "Kim@aol.com",
+        },
+      ],
+      table_signup: [
+        {
+          signup_id: 1,
+          project_id: 1,
+          signup_name: "Kathy",
+          signup_github_name: "CodeMeKathy",
+          signup_email: "Kathy@aol.com",
+        },
+        {
+          signup_id: 2,
+          project_id: 1,
+          signup_name: "Kim",
+          signup_github_name: "KimSlim",
+          signup_email: "Kim@aol.com",
+        },
+      ],
     },
     {
       project_id: 10,
@@ -161,6 +468,38 @@ export default {
       sign_up: 2,
       vote: 4,
       date: "10/20/2020",
+      table_vote: [
+        {
+          table_vote_id: 1,
+          project_id: 10,
+          voter_name: "Kathy",
+          voter_slack_name: "Kathy",
+          voter_email: "Kathy@aol.com",
+        },
+        {
+          table_vote_id: 2,
+          project_id: 10,
+          voter_name: "Kim",
+          voter_slack_name: "Kim",
+          voter_email: "Kim@aol.com",
+        },
+      ],
+      table_signup: [
+        {
+          signup_id: 1,
+          project_id: 1,
+          signup_name: "Kathy",
+          signup_github_name: "CodeMeKathy",
+          signup_email: "Kathy@aol.com",
+        },
+        {
+          signup_id: 2,
+          project_id: 1,
+          signup_name: "Kim",
+          signup_github_name: "KimSlim",
+          signup_email: "Kim@aol.com",
+        },
+      ],
     },
   ],
 };

--- a/client/src/routes/projectsPage.js
+++ b/client/src/routes/projectsPage.js
@@ -41,7 +41,7 @@ export default function ProjectsPage() {
             </li>
             <li>
               In development projects may still accept members.{" "}
-              <strong>contact us</strong> to find out how to get invloved.
+              <strong>contact us</strong> to find out how to get involved.
             </li>
           </ol>
         </div>

--- a/client/src/scss/components/FormHeader.scss
+++ b/client/src/scss/components/FormHeader.scss
@@ -2,19 +2,69 @@
   &__header {
     background-color: #e0e5f0;
     width: 76.97rem;
-    height: 7rem;
+    height: 14.25rem;
     display: flex;
+    flex-direction: column;
+    padding-top: 5.65rem;
+  }
+  &__row {
+    flex-direction: row;
+  }
+  &__col {
+    flex-direction: column;
+  }
+  &__toolbar {
     justify-content: space-evenly;
   }
-  &__btn {
-    height: 40px;
-    border-radius: 8px;
-    // margin: 12px 32px;
-    // background-color: #d71549;
+  &__header_title {
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    line-height: 1.761rem;
   }
-  &__btn :focus,
-  &__btn:hover {
+  &__project_info_container {
+    margin-left: 12.6rem;
+    margin-top: 1rem;
+  }
+  &__project_title {
+    font-size: 0.875rem;
+  }
+  &__project_title_input {
+    border-top-style: hidden;
+    border-right-style: hidden;
+    border-left-style: hidden;
+    // border-bottom-style: hidden;
+    -webskit-apperance: none;
+    box-shadow: none;
+    border-bottom: 1px solid black;
+    width: 47rem;
+    background-color: #e0e5f0;
+  }
+  &__btn_col {
+    height: 2.5rem;
+  }
+  &__btn {
+    // margin: 12px 32px;
+    color: #d71549;
+    border: 0;
+    font-family: inherit !important;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: transparent;
+    box-shadow: 0px 0px 0px transparent;
+    font-family: "Raleway", sans-serif !important;
+    font-weight: bold;
+    font-size: 0.875rem;
+    line-height: 1rem;
+    // -webkit-appearance: none;
+    // -moz-appearance: none;
+  }
+  &__btn:focus,
+  &__btn:hover,
+  &__btn:active {
+    height: 2.5rem;
     background-color: #d71549;
     color: whitesmoke;
+    border-radius: 0.5rem;
+    padding: 12px, 32px, 12px, 32px;
   }
 }

--- a/client/src/scss/components/FormHeader.scss
+++ b/client/src/scss/components/FormHeader.scss
@@ -1,0 +1,20 @@
+.adminEditProjectForm {
+  &__header {
+    background-color: #e0e5f0;
+    width: 76.97rem;
+    height: 7rem;
+    display: flex;
+    justify-content: space-evenly;
+  }
+  &__btn {
+    height: 40px;
+    border-radius: 8px;
+    // margin: 12px 32px;
+    // background-color: #d71549;
+  }
+  &__btn :focus,
+  &__btn:hover {
+    background-color: #d71549;
+    color: whitesmoke;
+  }
+}

--- a/client/src/scss/components/_adminEditProjectForm.scss
+++ b/client/src/scss/components/_adminEditProjectForm.scss
@@ -4,6 +4,13 @@
     // margin: 0 auto;
     height: 100%;
   }
+  &__form {
+    display: flex;
+    flex-direction: column;
+  }
+  &__form_container {
+    justify-content: center;
+  }
   &__form_row {
     display: flex;
     flex-direction: row;

--- a/client/src/scss/components/_adminEditProjectForm.scss
+++ b/client/src/scss/components/_adminEditProjectForm.scss
@@ -28,8 +28,9 @@
     margin-bottom: 1.5rem;
   }
 
-  // &__form_container {
-  // }
+  &__header {
+    width: 77.97rem !important;
+  }
   &__form_row {
     display: flex;
     flex-direction: row;

--- a/client/src/scss/components/_adminEditProjectForm.scss
+++ b/client/src/scss/components/_adminEditProjectForm.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   width: 70vw;
+  place-content: center;
 }
 .adminEditProjectForm_form_row {
   flex-direction: row;

--- a/client/src/scss/components/_adminEditProjectForm.scss
+++ b/client/src/scss/components/_adminEditProjectForm.scss
@@ -1,27 +1,60 @@
-.adminEditProjectForm_container {
-  background-color: #fff;
-  display: flex;
-  // flex-direction: column;
-  // width: 70vw;
-  justify-content: center;
+.adminEditProjectForm {
+  &__container {
+    // background-color: #fff;
+    // margin: 0 auto;
+    height: 100%;
+  }
+  &__form_row {
+    display: flex;
+    flex-direction: row;
+    // background-color: palegreen;
+  }
+  &__form_col {
+    display: flex;
+    flex-direction: column;
+    // margin-right: 5.5rem !important;
+    // background-color: purple;
+  }
+  &__contact_info {
+    border-radius: 8px;
+    width: 17rem;
+  }
+  &__textarea {
+    border-radius: 8px;
+    width: max-content;
+    padding: 2rem 3.5rem;
+  }
+  &__section_header {
+    font-size: 24px;
+    line-height: 28px;
+    text-transform: uppercase;
+  }
+  &__section_sub_header {
+    font-size: 14px;
+    line-height: 16px;
+    color: #434447;
+  }
+  &__horizontal_line {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  }
 }
-.adminEditProjectForm_form_row {
-  display: flex;
-  flex-direction: row;
-  // background-color: palegreen;
+
+table {
+  // background-color: #e0e5f0;
+  width: 76.97rem;
 }
-.adminEditProjectForm_form_col {
-  display: flex;
-  flex-direction: column;
-  margin-right: 5.5rem !important;
-  // background-color: purple;
+thead {
+  background-color: #e0e5f0;
+  color: #434447;
+  // width: 76.97rem;
 }
-input {
-  border-radius: 8px;
-  width: 17rem;
+.members_voted__member_data {
+  border-bottom: 1px solid #0000001a;
+  font-size: 18px;
+  line-height: 48px;
+  color: #434447;
 }
-textarea {
-  border-radius: 8px;
-  width: max-content;
-  padding: 2rem 3.5rem;
+// #2D3748
+.adminEditProjectForm__table_header {
+  border-top: 1px solid #2d3748;
 }

--- a/client/src/scss/components/_adminEditProjectForm.scss
+++ b/client/src/scss/components/_adminEditProjectForm.scss
@@ -4,13 +4,32 @@
     // margin: 0 auto;
     height: 100%;
   }
+  &__form_container_col {
+    display: flex;
+    // flex-direction: column;
+    justify-content: center;
+    padding-bottom: 4rem;
+    margin: 0 auto;
+    font-family: inherit;
+  }
   &__form {
     display: flex;
     flex-direction: column;
+    width: 50vw;
   }
-  &__form_container {
-    justify-content: center;
+  &__contact_info {
+    background-color: #ffffff;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+    margin-top: 2rem;
   }
+  &__company_info {
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+  }
+
+  // &__form_container {
+  // }
   &__form_row {
     display: flex;
     flex-direction: row;
@@ -22,24 +41,112 @@
     // margin-right: 5.5rem !important;
     // background-color: purple;
   }
-  &__contact_info {
-    border-radius: 8px;
-    width: 17rem;
+  &__contact_input {
+    border-radius: 0.5rem;
+    width: 21rem;
+    height: 3rem;
+    border-top-style: hidden;
+    border-right-style: hidden;
+    border-left-style: hidden;
+    // border-bottom-style: hidden;
+    -webskit-apperance: none;
+    box-shadow: none;
+    border: 1px solid #000000;
+    padding-left: 1rem;
   }
   &__textarea {
     border-radius: 8px;
     width: max-content;
-    padding: 2rem 3.5rem;
+    padding: 2rem 7rem;
+    font-family: inherit;
+    box-shadow: none;
+    border: 1px solid black;
+  }
+  &__checkbox_squares {
+    margin-top: 2.5rem;
+  }
+  &__tech_stack_header {
+    font-size: 0.875rem;
+    line-height: 1.028rem;
+    color: #434447;
+    margin-bottom: 0.8rem;
+  }
+  &__project_tech_container {
+    margin-right: 1.5rem;
+  }
+  &__project_status_container {
+    margin-left: 1.5rem;
+  }
+  &__form_container_square {
+    background-color: rgba(221, 226, 229, 0.369);
+    width: 21rem;
+    height: 12rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+  &__input_checkbox {
+    outline: 1px solid #000000;
+    margin-right: 0.8rem;
+    margin-left: 1.8rem;
+    box-shadow: none;
+  }
+  &__square_row {
+    width: 21rem;
+    padding-top: 1rem;
+  }
+  &__square_col {
+    width: 10.5rem;
+  }
+  &__lang_add_btn {
+    // margin: 12px 32px;
+    color: #d71549;
+    width: 5rem;
+    border: 1px solid #434447;
+    border-radius: 0.5rem;
+    background-color: #fff;
+    font-family: inherit !important;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: transparent;
+    box-shadow: 0px 0px 0px transparent;
+    font-family: "Raleway", sans-serif !important;
+    font-weight: bold;
+    font-size: 0.875rem;
+    line-height: 1rem;
+  }
+  &__lang_add_row {
+    margin-bottom: 1.5rem;
+  }
+  &__lang_input {
+    border-radius: 0.5rem;
+    width: 13rem;
+    height: 2rem;
+    border-top-style: hidden;
+    border-right-style: hidden;
+    border-left-style: hidden;
+    // border-bottom-style: hidden;
+    -webskit-apperance: none;
+    box-shadow: none;
+    border: 1px solid #000000;
+    padding-left: 1rem;
+    margin-right: 0.5rem;
+    margin-left: 1rem;
   }
   &__section_header {
-    font-size: 24px;
-    line-height: 28px;
+    font-size: 1.5rem;
+    line-height: 1.75rem;
     text-transform: uppercase;
+    font-weight: 400;
+    margin-top: 2.75rem;
+    font-weight: 400;
   }
   &__section_sub_header {
-    font-size: 14px;
-    line-height: 16px;
+    font-size: 1rem;
+    line-height: 1rem;
     color: #434447;
+    margin-top: 1.5rem;
+    padding-bottom: 0.5rem;
   }
   &__horizontal_line {
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
@@ -48,20 +155,25 @@
 
 table {
   // background-color: #e0e5f0;
-  width: 76.97rem;
+  width: 50vw;
+  margin-bottom: 4rem;
 }
-thead {
+thead,
+th {
   background-color: #e0e5f0;
   color: #434447;
-  // width: 76.97rem;
+  width: 50vw;
+}
+.memberData__container {
+  width: 50vw;
 }
 .members_voted__member_data {
-  border-bottom: 1px solid #0000001a;
+  border-bottom: 3px solid #0000001a;
   font-size: 18px;
   line-height: 48px;
   color: #434447;
 }
 // #2D3748
 .adminEditProjectForm__table_header {
-  border-top: 1px solid #2d3748;
+  border-top: 2px solid #2d3748;
 }

--- a/client/src/scss/components/_adminEditProjectForm.scss
+++ b/client/src/scss/components/_adminEditProjectForm.scss
@@ -1,0 +1,15 @@
+.adminEditProjectForm_container {
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  width: 70vw;
+}
+.adminEditProjectForm_form_row {
+  flex-direction: row;
+  background-color: palegreen;
+}
+.adminEditProjectForm_form_col {
+  display: flex;
+  flex-direction: column;
+  background-color: purple;
+}

--- a/client/src/scss/components/_adminEditProjectForm.scss
+++ b/client/src/scss/components/_adminEditProjectForm.scss
@@ -1,16 +1,27 @@
 .adminEditProjectForm_container {
   background-color: #fff;
   display: flex;
-  flex-direction: column;
-  width: 70vw;
-  place-content: center;
+  // flex-direction: column;
+  // width: 70vw;
+  justify-content: center;
 }
 .adminEditProjectForm_form_row {
+  display: flex;
   flex-direction: row;
-  background-color: palegreen;
+  // background-color: palegreen;
 }
 .adminEditProjectForm_form_col {
   display: flex;
   flex-direction: column;
-  background-color: purple;
+  margin-right: 5.5rem !important;
+  // background-color: purple;
+}
+input {
+  border-radius: 8px;
+  width: 17rem;
+}
+textarea {
+  border-radius: 8px;
+  width: max-content;
+  padding: 2rem 3.5rem;
 }

--- a/client/src/scss/components/_adminEditProjectForm.scss
+++ b/client/src/scss/components/_adminEditProjectForm.scss
@@ -29,7 +29,7 @@
   }
 
   &__header {
-    width: 77.97rem !important;
+    width: 78.1rem !important;
   }
   &__form_row {
     display: flex;

--- a/client/src/scss/components/_adminProjectDetails.scss
+++ b/client/src/scss/components/_adminProjectDetails.scss
@@ -1,0 +1,12 @@
+.admin_project_details {
+  display: flex;
+  flex-direction: row;
+
+  &__container {
+    background-color: grey; // Remove
+    flex-direction: column;
+    width: 85.2vw;
+    height: 100vh;
+    float: right;
+  }
+}

--- a/client/src/scss/components/_adminProjectDetails.scss
+++ b/client/src/scss/components/_adminProjectDetails.scss
@@ -1,14 +1,30 @@
-.admin_project_details {
-  display: flex;
-  flex-direction: row;
+// .admin_project_details {
+//   display: flex;
+//   flex-direction: row;
 
+//   &__container {
+//     display: flex;
+//     background-color: grey; // Remove
+//     flex-direction: column;
+//     // width: 85.2%;
+//     height: 100%;
+//     // justify-content: center;
+//     margin: 0 auto;
+//   }
+// }
+
+.admin_project_details {
   &__container {
     display: flex;
-    background-color: grey; // Remove
-    flex-direction: column;
-    width: 85.2vw;
-    height: 100vh;
-    // float: right;
+    flex-direction: row;
 
+    // background-color: grey; // Remove
+    // width: 80%;
+    // float: right;
+  }
+  &__form_container {
+    display: flex;
+    justify-content: center;
+    height: 110%;
   }
 }

--- a/client/src/scss/components/_adminProjectDetails.scss
+++ b/client/src/scss/components/_adminProjectDetails.scss
@@ -3,10 +3,12 @@
   flex-direction: row;
 
   &__container {
+    display: flex;
     background-color: grey; // Remove
     flex-direction: column;
     width: 85.2vw;
     height: 100vh;
-    float: right;
+    // float: right;
+
   }
 }

--- a/client/src/scss/components/_index.scss
+++ b/client/src/scss/components/_index.scss
@@ -22,3 +22,4 @@
 @import "./adminPanelHeader";
 @import "./adminProjectDetails";
 @import "./adminEditProjectForm";
+@import "./FormHeader";

--- a/client/src/scss/components/_index.scss
+++ b/client/src/scss/components/_index.scss
@@ -5,8 +5,6 @@
 @import "./accordion";
 @import "./projects";
 @import "./modal";
-@import "./adminPanel";
-@import "./adminPanelHeader";
 @import "./sideBar";
 @import "./header";
 @import "./headersmall";
@@ -18,3 +16,8 @@
 @import "./notfound";
 @import "./form";
 @import "./search";
+
+// Admin Panel Styling
+@import "./adminPanel";
+@import "./adminPanelHeader";
+@import "./adminProjectDetails";

--- a/client/src/scss/components/_index.scss
+++ b/client/src/scss/components/_index.scss
@@ -21,3 +21,4 @@
 @import "./adminPanel";
 @import "./adminPanelHeader";
 @import "./adminProjectDetails";
+@import "./adminEditProjectForm";

--- a/client/src/scss/components/_sideBar.scss
+++ b/client/src/scss/components/_sideBar.scss
@@ -4,7 +4,7 @@
     justify-content: flex-start;
     font-family: "Raleway", sans-serif;
     width: 13rem !important;
-    height: 100vh !important;
+    height: 100% !important;
     background-color: #262e3d;
     padding: 0 !important;
     margin-left: -18px;


### PR DESCRIPTION
## Description

This pull request adds a new Admin Project Details page to match the redesigned mockup similarly.

## Related Issue
#41 

## Acceptance Criteria
- [x] The Admin Project Details layout to match the redesigned mockup (the screen an authenticated user accesses to view the project details with contact information) looks similar to the redesigned mockup:

![Admin Project List filled form (1)](https://user-images.githubusercontent.com/32943879/100558360-200d2d00-327c-11eb-91ef-cda62348b2d1.jpg)

## Type of Changes

|    | Type                       |
|--- | -------------------------- |
|    | :bug: Bug fix              |
| ✓  | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

This is a new page and did not previously exist.

### After
![AdminProjectDetails ProjectHub](https://user-images.githubusercontent.com/32943879/100649633-b5f29780-3310-11eb-98cb-37670429ee9a.png)

## Testing Steps / QA Criteria

- In the terminal, run `git checkout feature-admin-project-details` to checkout to the `feature-admin-project-details` branch.
- From the terminal, cd to the `client` directory and run `npm start` to load the server and start the browser.
- In the browser, visit the `<AdminEditProjectForm/>` component by first selecting the `ADMIN` link on the top left of the navigation bar on the home page, at http://localhost:3000.
- Once on the Admin Panel page, at http://localhost:3000/admin, select any of the listed projects to view its details in the `<AdminEditProjectForm/>`.